### PR TITLE
feat(search): Introduce denormalized searchBlob field

### DIFF
--- a/src/components/entry-list.tsx
+++ b/src/components/entry-list.tsx
@@ -319,9 +319,8 @@ export function EntryList({ search, filter }: EntryListProps) {
         // Test the regex string before using it
         new RegExp(escapedSearch, "i");
 
-        // RxDB requires the regex operator to be a string
-        selector.title = { $regex: escapedSearch, $options: "i" };
-        //? Maybe add description too, though preferably only indexed fields.
+        // Query against the pre-lowercased searchBlob (title + tags + description snippet + siteName)
+        selector.searchBlob = { $regex: escapedSearch.toLowerCase() };
       } catch (error) {
         console.error("Failed to compile search regex:", error);
       }

--- a/src/components/topic-list.tsx
+++ b/src/components/topic-list.tsx
@@ -272,11 +272,8 @@ export function TopicList({ search, filter }: TopicListProps) {
         // Test the regex string before using it
         new RegExp(escapedSearch, "i");
 
-        // RxDB requires the regex operator to be a string
-        const searchRegex = { $regex: escapedSearch, $options: "i" };
-        selector.$or = [{ name: searchRegex }, { tags: searchRegex }];
-        // TODO: Potentially add tags to the search.
-        //? Maybe add description too, though preferably only indexed fields.
+        // Query against the pre-lowercased searchBlob (name + tags + description snippet)
+        selector.searchBlob = { $regex: escapedSearch.toLowerCase() };
       } catch (error) {
         console.error("Failed to compile search regex:", error);
       }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,6 +8,7 @@ import { topicSchema } from "./schemas/topic";
 import { entrySchema } from "./schemas/entry";
 import { blockSchema } from "./schemas/block";
 import { filterConsole } from "@/lib/utils/filter-console";
+import { buildEntrySearchBlob, buildTopicSearchBlob } from "./search-blob";
 
 const isDev = import.meta.env.DEV;
 
@@ -37,6 +38,24 @@ export async function initializeDb() {
     entries: { schema: entrySchema },
     blocks: { schema: blockSchema },
   });
+
+  // --- searchBlob middleware hooks ---
+  // Automatically populate the searchBlob field on insert and update
+  // so queries only need to scan a single denormalized string field.
+
+  db.entries.preInsert((doc) => {
+    doc.searchBlob = buildEntrySearchBlob(doc);
+  }, false); // maybe change to parallel if more hooks are added
+  db.entries.preSave((doc) => {
+    doc.searchBlob = buildEntrySearchBlob(doc);
+  }, false); // maybe change to parallel if more hooks are added
+
+  db.topics.preInsert((doc) => {
+    doc.searchBlob = buildTopicSearchBlob(doc);
+  }, false); // maybe change to parallel if more hooks are added
+  db.topics.preSave((doc) => {
+    doc.searchBlob = buildTopicSearchBlob(doc);
+  }, false); // maybe change to parallel if more hooks are added
 
   // Seed dummy data if in development mode
   if (isDev) {

--- a/src/db/schemas/entry.ts
+++ b/src/db/schemas/entry.ts
@@ -31,6 +31,8 @@ const entrySchemaLiteral = {
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
     siteName: { type: 'string', maxLength: 255 },
+    // INTERNAL:
+    searchBlob: { type: 'string', maxLength: 3000 }, // Auto-populated denormalized search field (title + tags + description snippet + siteName)
     //excerpt: { type: 'string' }, // not needed currently, put in description for now.
     //byline: { type: 'string' }, // not needed currently, put in description for now.
     //publishedAt: { type: 'string', format: 'date-time' } //not needed currently, put in description for now.

--- a/src/db/schemas/topic.ts
+++ b/src/db/schemas/topic.ts
@@ -21,7 +21,9 @@ const topicSchemaLiteral = {
     isPinned: { type: 'boolean' },
     isArchived: { type: 'boolean' },
     createdAt: { type: 'string', format: 'date-time' },
-    updatedAt: { type: 'string', format: 'date-time' }
+    updatedAt: { type: 'string', format: 'date-time' },
+    // INTERNAL:
+    searchBlob: { type: 'string', maxLength: 2000 }, // Auto-populated denormalized search field (name + tags + description snippet)
   },
   required: ['id', 'userId', 'name', 'tags', 'isFavorite', 'isPinned', 'isArchived', 'createdAt', 'updatedAt'],
   indexes: ['userId', ['isPinned', 'updatedAt'], ['isArchived', 'isPinned', 'updatedAt']]

--- a/src/db/search-blob.ts
+++ b/src/db/search-blob.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared utilities for building the `searchBlob` denormalized search field.
+ *
+ * The searchBlob concatenates key text fields into a single lowercase string,
+ * allowing global search to query a single property instead of multiple fields.
+ */
+const DESCRIPTION_MAX_LENGTH = 150;
+
+/** Truncates a string to the given max length. */
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+/** Flattens a tags array into a lowercase, space-separated string. */
+function flattenTags(tags?: string[]): string {
+  if (!Array.isArray(tags) || tags.length === 0) return '';
+  return tags.map((t) => t.toLowerCase().trim()).join(' ');
+}
+
+/** Builds a searchBlob for an entry document. */
+export function buildEntrySearchBlob(doc: {
+  title?: string;
+  description?: string;
+  tags?: string[];
+  siteName?: string;
+}): string {
+  const parts = [
+    (doc.title || '').toLowerCase().trim(),
+    flattenTags(doc.tags),
+    truncate((doc.description || '').toLowerCase().trim(), DESCRIPTION_MAX_LENGTH),
+    (doc.siteName || '').toLowerCase().trim(),
+  ];
+
+  return parts.filter(Boolean).join(' ').replace(/\s{2,}/g, ' ').trim();
+}
+
+/** Builds a searchBlob for a topic document. */
+export function buildTopicSearchBlob(doc: {
+  name?: string;
+  description?: string;
+  tags?: string[];
+}): string {
+  const parts = [
+    (doc.name || '').toLowerCase().trim(),
+    flattenTags(doc.tags),
+    truncate((doc.description || '').toLowerCase().trim(), DESCRIPTION_MAX_LENGTH),
+  ];
+
+  return parts.filter(Boolean).join(' ').replace(/\s{2,}/g, ' ').trim();
+}


### PR DESCRIPTION
This pull request introduces a denormalized `searchBlob` field for both entries and topics to improve global search performance and consistency. The `searchBlob` field is automatically populated on insert and update, and search queries are updated to use this field instead of querying multiple properties. Supporting utilities and schema changes are also included.

**Search Functionality Improvements:**

- Updated search queries in `EntryList` and `TopicList` components to use the new `searchBlob` field, enabling more efficient and consistent global search across key text fields. [[1]](diffhunk://#diff-b40d791568724c8885591abad8224abbb23c8b40caf8fd76ee7a5e0bac415f08L322-R323) [[2]](diffhunk://#diff-2d9908f528e28181accbe1004cb0a24aab796d6319111dc20d773170e55d6ce4L275-R276)

**Database Schema and Middleware:**

- Added a `searchBlob` field to both `entrySchema` and `topicSchema` for denormalized search data, with appropriate max lengths. [[1]](diffhunk://#diff-a78f2dbf3385dffc3c6afa411abd584da28508cf1f5eee0990adef9a5f3622eeR34-R35) [[2]](diffhunk://#diff-4a3e7b9d9b4e362eb7c54620581789ced6ddbf29a1ad892e8d29155f14491841L24-R26)
- Registered RxDB middleware hooks in `initializeDb` to automatically populate `searchBlob` on insert and update for both entries and topics.

**Utility Functions:**

- Introduced `buildEntrySearchBlob` and `buildTopicSearchBlob` utility functions in a new `search-blob.ts` file to generate the denormalized search string from relevant fields. [[1]](diffhunk://#diff-bb7908976b5cd74ee6c8a84599bb111f8fb0eb28ecf18c9be448fd87c8e4bfb0R1-R50) [[2]](diffhunk://#diff-c7d2c320d1f7fc0aad36b8bf616a7289ca4dcf00e6e057ba8a1d354fb25b74c0R11)