### PR TITLE
chore: Infrastructure cleanup - RxDB indexes, remove unused permissions

### DIFF
--- a/src/components/entry-list.tsx
+++ b/src/components/entry-list.tsx
@@ -425,7 +425,7 @@ export function EntryList({
     if (onlyArchived) {
       selector.isArchived = true;
     } else {
-      selector.isArchived = { $ne: true };
+      selector.isArchived = false;
     }
 
     if (onlyFavorites) {

--- a/src/components/topic-list.tsx
+++ b/src/components/topic-list.tsx
@@ -72,7 +72,7 @@ function TopicItem({ topic, topUIScrollOffset }: TopicItemProps) {
             .find({
               selector: {
                 topicId: topic.id,
-                archivedExplicitly: { $ne: true },
+                archivedExplicitly: false,
               },
             })
             .exec();
@@ -377,7 +377,7 @@ export function TopicList({
     if (onlyArchived) {
       selector.isArchived = true;
     } else {
-      selector.isArchived = { $ne: true };
+      selector.isArchived = false;
     }
 
     if (onlyFavorites) {

--- a/src/db/schemas/entry.ts
+++ b/src/db/schemas/entry.ts
@@ -46,9 +46,10 @@ const entrySchemaLiteral = {
     'topicId', 
     'title', 
     'tags', 
-    'isFavorite', 
+    'isFavorite',
     'isPinned',
     'isArchived',
+    'archivedExplicitly',
     'languageCode', 
     'url', // (not strictly required, empty allowed)
     'hostnameUrl', // (not strictly required, empty allowed)

--- a/src/db/schemas/entry.ts
+++ b/src/db/schemas/entry.ts
@@ -57,7 +57,16 @@ const entrySchemaLiteral = {
     'createdAt',
     'updatedAt'
   ],
-  indexes: ['topicId', 'userId', ['isPinned', 'updatedAt'], ['topicId', 'isArchived', 'isPinned', 'updatedAt']] // TODO: Adjust compound indexes as needed based on query patterns (e.g., topicId + createdAt for sorting entries within a topic)
+  indexes: [
+    'topicId',
+    'userId',
+    ['isPinned', 'updatedAt'],
+    ['isArchived', 'isPinned', 'updatedAt'],
+    ['isFavorite', 'isArchived', 'isPinned', 'updatedAt'],
+    ['topicId', 'isArchived', 'isPinned', 'updatedAt'],
+    ['topicId', 'isFavorite', 'isArchived', 'isPinned', 'updatedAt'],
+    ['topicId', 'archivedExplicitly'],
+  ]
 } as const;
 
 export const entrySchema = toTypedRxJsonSchema(entrySchemaLiteral);

--- a/src/db/schemas/topic.ts
+++ b/src/db/schemas/topic.ts
@@ -10,7 +10,7 @@ const topicSchemaLiteral = {
   properties: {
     id: uuidSchema,
     userId: uuidWithNilDefault,
-    name: { type: 'string', maxLength: 255 }, // TODO: Potentially index this field.
+    name: { type: 'string', maxLength: 255 },
     description: { type: 'string', maxLength: 1000 },
     tags: {
       type: 'array',
@@ -26,7 +26,12 @@ const topicSchemaLiteral = {
     searchBlob: { type: 'string', maxLength: 2020 }, // Auto-populated denormalized search field (name + tags + description snippet + updatedAt date tokens)
   },
   required: ['id', 'userId', 'name', 'tags', 'isFavorite', 'isPinned', 'isArchived', 'createdAt', 'updatedAt'],
-  indexes: ['userId', ['isPinned', 'updatedAt'], ['isArchived', 'isPinned', 'updatedAt']]
+  indexes: [
+    'userId',
+    ['isPinned', 'updatedAt'],
+    ['isArchived', 'isPinned', 'updatedAt'],
+    ['isFavorite', 'isArchived', 'isPinned', 'updatedAt'],
+  ]
 } as const;
 
 export const topicSchema = toTypedRxJsonSchema(topicSchemaLiteral);

--- a/src/entrypoints/sidepanel/pages/library/topics/detail/topic-detail.tsx
+++ b/src/entrypoints/sidepanel/pages/library/topics/detail/topic-detail.tsx
@@ -69,7 +69,7 @@ function TopicDetailPage() {
 
     const sub = entriesCollection
       .find({
-        selector: { topicId: id, isFavorite: true, isArchived: { $ne: true } },
+        selector: { topicId: id, isFavorite: true, isArchived: false },
         sort: [{ updatedAt: "desc" }],
       })
       .$.subscribe({
@@ -108,7 +108,7 @@ function TopicDetailPage() {
     if (attribute === "isArchived" && entriesCollection) {
       const implicitEntries = await entriesCollection
         .find({
-          selector: { topicId: topic.id, archivedExplicitly: { $ne: true } },
+          selector: { topicId: topic.id, archivedExplicitly: false },
         })
         .exec();
       await Promise.all(

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -39,8 +39,6 @@ export default defineConfig({
         "scripting",
         "contextMenus",
         "clipboardRead",
-        "alarms",
-        "notifications",
         "sidePanel",
       ],
       //host_permissions: ["<all_urls>"], //* NOTE: Not needed, activeTab should be enough


### PR DESCRIPTION
## Summary

- **RxDB schema indexes (#84)** — Audited all query sites in `topic-list.tsx` and `entry-list.tsx` and added the missing compound indexes:
  - `topics`: `['isFavorite', 'isArchived', 'isPinned', 'updatedAt']`
  - `entries`: `['isArchived', 'isPinned', 'updatedAt']` (global/no-topicId queries), `['isFavorite', 'isArchived', 'isPinned', 'updatedAt']` (global favorites), `['topicId', 'isFavorite', 'isArchived', 'isPinned', 'updatedAt']` (per-topic favorites), `['topicId', 'archivedExplicitly']` (cascade archive/restore)
  - No version bump or migration strategy needed — app is pre-production
- **Remove unused browser permissions (#86)** — Dropped `alarms` and `notifications` from `wxt.config.ts`; neither is referenced anywhere in the codebase
- **Prune unused packages (#48)** — Manual + targeted audit found no unused packages; `@base-ui/react` (initially flagged) is used in `src/components/ui/combobox.tsx`; closing as clean

## Test plan

- [x] `bun run test` — 43 tests pass
- [x] `bun run compile` — pre-existing errors only (in `block-converter.test.ts`, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)