### PR TITLE
feat: Implement settings sub-pages (data, FAQ, tips, about, licenses)

### DIFF
--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -46,6 +46,11 @@ import SettingsPage from "./pages/settings/settings";
 // Sub-settings pages
 import ThemePersonalizationSettingsPage from "./pages/settings/personalization/theme";
 import CaptureSuggestionsSettingsPage from "./pages/settings/features/capture-suggestions";
+import DataSettingsPage from "./pages/settings/data/data";
+import FaqPage from "./pages/settings/help/faq";
+import TipsAndTricksPage from "./pages/settings/help/tips-and-tricks";
+import AboutPage from "./pages/settings/about/about";
+import LicensesPage from "./pages/settings/about/licenses";
 // import NotificationsSettingsPage from "./pages/settings/notifications";
 
 function RootLayout() {
@@ -108,6 +113,14 @@ const router = createMemoryRouter([
         path: "settings/capture-suggestions",
         element: <CaptureSuggestionsSettingsPage />,
       },
+      { path: "settings/data", element: <DataSettingsPage /> },
+      { path: "settings/help/faq", element: <FaqPage /> },
+      {
+        path: "settings/help/tips-and-tricks",
+        element: <TipsAndTricksPage />,
+      },
+      { path: "settings/about", element: <AboutPage /> },
+      { path: "settings/about/licenses", element: <LicensesPage /> },
     ],
   },
 ]);

--- a/src/entrypoints/sidepanel/pages/settings/about/about.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/about/about.tsx
@@ -1,3 +1,5 @@
+import lexicoraLightThemeLogoNoBg from "@/assets/logos/lexicora_inverted_no-bg.svg";
+import lexicoraDarkThemeLogoNoBg from "@/assets/logos/lexicora_standard_no-bg.svg";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import {
@@ -17,14 +19,33 @@ function AboutPage() {
   return (
     <PageContainer>
       <PageHeader title="About" goBackButton />
-      <main className="flex flex-col gap-6 w-full pt-4.5 px-1.25 mb-1">
+      <main className="flex flex-col gap-6 w-full pt-4.5 px-1.25 mb-2">
         <section>
           <Item
             variant="muted"
             size="default"
             className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl flex-col items-center py-6 gap-2 text-center"
           >
-            <h2 className="text-2xl font-bold tracking-tight">Lexicora</h2>
+            <span className="flex justify-center gap-1.5 items-baseline mb-3">
+              {/*Maybe add link to lexicora.com */}
+              <img
+                src={lexicoraLightThemeLogoNoBg}
+                className="h-[1.06rem] lc-display-light rounded-xs"
+                alt="Lexicora logo"
+                draggable="false"
+              />
+              <img
+                src={lexicoraDarkThemeLogoNoBg}
+                className="h-[1.06rem] lc-display-dark rounded-xs"
+                alt="Lexicora logo"
+                draggable="false"
+              />
+              {/*#00143d is the Lexicora color */}
+              <h2 className="text-2xl font-bold text-[#00143d] dark:text-foreground leading-0">
+                Lexicora
+              </h2>
+            </span>
+            {/*<h2 className="text-2xl font-bold tracking-tight">Lexicora</h2>*/}
             <p className="text-xs text-muted-foreground">
               Capture. Organize. Remember.
             </p>
@@ -38,7 +59,7 @@ function AboutPage() {
             className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl rounded-b-none"
           >
             <ItemContent>
-              <ItemDescription className="line-clamp-none text-foreground/80">
+              <ItemDescription className="line-clamp-none text-foreground/80 text-pretty">
                 A browser extension for capturing and organizing web content.
                 Save pages, highlight text, and write notes — all stored
                 locally, always private, fully offline.
@@ -70,19 +91,23 @@ function AboutPage() {
             className="group transition-colors duration-150 bg-slate-200/75 hover:bg-slate-300/75! dark:bg-muted/50 dark:hover:bg-muted! rounded-2xl"
             asChild
           >
-            <Link to="/settings/about/licenses" draggable={false} viewTransition>
+            <Link
+              to="/settings/about/licenses"
+              draggable={false}
+              viewTransition
+            >
               <ItemMedia variant="icon">
                 <FileTextIcon className="size-5 text-emerald-500" />
               </ItemMedia>
               <ItemContent>
                 <ItemTitle>Open Source Licenses</ItemTitle>
-                <ItemDescription>
-                  Libraries and tools that make Lexicora possible
-                </ItemDescription>
               </ItemContent>
               <ChevronRightIcon className="size-4 transition-colors duration-150 text-muted-foreground group-hover:text-lc-muted-foreground-hover" />
             </Link>
           </Item>
+          <p className="text-pretty text-xs text-muted-foreground mx-2.5 mt-1">
+            Libraries and tools that make Lexicora possible.
+          </p>
         </section>
       </main>
     </PageContainer>

--- a/src/entrypoints/sidepanel/pages/settings/about/about.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/about/about.tsx
@@ -1,0 +1,92 @@
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+} from "@/components/ui/item";
+import { SettingsItemSeperator } from "@/components/settings";
+import { ChevronRightIcon, FileTextIcon, TagIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+
+function AboutPage() {
+  const version = browser.runtime.getManifest().version;
+
+  return (
+    <PageContainer>
+      <PageHeader title="About" goBackButton />
+      <main className="flex flex-col gap-6 w-full pt-4.5 px-1.25 mb-1">
+        <section>
+          <Item
+            variant="muted"
+            size="default"
+            className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl flex-col items-center py-6 gap-2 text-center"
+          >
+            <h2 className="text-2xl font-bold tracking-tight">Lexicora</h2>
+            <p className="text-xs text-muted-foreground">
+              Capture. Organize. Remember.
+            </p>
+          </Item>
+        </section>
+
+        <section>
+          <Item
+            variant="muted"
+            size="sm"
+            className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl rounded-b-none"
+          >
+            <ItemContent>
+              <ItemDescription className="line-clamp-none text-foreground/80">
+                A browser extension for capturing and organizing web content.
+                Save pages, highlight text, and write notes — all stored
+                locally, always private, fully offline.
+              </ItemDescription>
+            </ItemContent>
+          </Item>
+          <SettingsItemSeperator />
+          <Item
+            variant="muted"
+            size="sm"
+            className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl rounded-t-none"
+          >
+            <ItemMedia variant="icon">
+              <TagIcon className="size-5 text-muted-foreground" />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Version</ItemTitle>
+            </ItemContent>
+            <span className="text-sm text-muted-foreground ml-auto">
+              {version}
+            </span>
+          </Item>
+        </section>
+
+        <section>
+          <Item
+            variant="muted"
+            size="sm"
+            className="group transition-colors duration-150 bg-slate-200/75 hover:bg-slate-300/75! dark:bg-muted/50 dark:hover:bg-muted! rounded-2xl"
+            asChild
+          >
+            <Link to="/settings/about/licenses" draggable={false} viewTransition>
+              <ItemMedia variant="icon">
+                <FileTextIcon className="size-5 text-emerald-500" />
+              </ItemMedia>
+              <ItemContent>
+                <ItemTitle>Open Source Licenses</ItemTitle>
+                <ItemDescription>
+                  Libraries and tools that make Lexicora possible
+                </ItemDescription>
+              </ItemContent>
+              <ChevronRightIcon className="size-4 transition-colors duration-150 text-muted-foreground group-hover:text-lc-muted-foreground-hover" />
+            </Link>
+          </Item>
+        </section>
+      </main>
+    </PageContainer>
+  );
+}
+
+export default AboutPage;

--- a/src/entrypoints/sidepanel/pages/settings/about/licenses.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/about/licenses.tsx
@@ -1,0 +1,69 @@
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { Item } from "@/components/ui/item";
+
+const LICENSES: { name: string; license: string }[] = [
+  { name: "@blocknote/core", license: "MPL-2.0" },
+  { name: "@blocknote/react", license: "MPL-2.0" },
+  { name: "@blocknote/shadcn", license: "MPL-2.0" },
+  { name: "@heroicons/react", license: "MIT" },
+  { name: "@hookform/resolvers", license: "MIT" },
+  { name: "@radix-ui/*", license: "MIT" },
+  { name: "@webext-core/messaging", license: "MIT" },
+  { name: "class-variance-authority", license: "Apache-2.0" },
+  { name: "clsx", license: "MIT" },
+  { name: "DOMPurify", license: "Apache-2.0" },
+  { name: "lucide-react", license: "ISC" },
+  { name: "next-themes", license: "MIT" },
+  { name: "React", license: "MIT" },
+  { name: "React DOM", license: "MIT" },
+  { name: "React Hook Form", license: "MIT" },
+  { name: "React Router", license: "MIT" },
+  { name: "React Virtuoso", license: "MIT" },
+  { name: "RxDB", license: "Apache-2.0" },
+  { name: "RxJS", license: "Apache-2.0" },
+  { name: "Sonner", license: "MIT" },
+  { name: "Tailwind CSS", license: "MIT" },
+  { name: "Turndown", license: "MIT" },
+  { name: "uuidv7", license: "MIT" },
+  { name: "WXT", license: "MIT" },
+  { name: "Zod", license: "MIT" },
+];
+
+function LicensesPage() {
+  return (
+    <PageContainer>
+      <PageHeader title="Licenses" goBackButton />
+      <main className="flex flex-col gap-6 w-full pt-4.5 px-1.25 mb-1">
+        <section>
+          <p className="text-sm text-muted-foreground ml-2 mb-3">
+            Lexicora is built on the shoulders of these open source projects.
+          </p>
+          <Item
+            variant="muted"
+            size="xs"
+            className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl flex-col items-stretch p-0 overflow-hidden"
+          >
+            {LICENSES.map((lib, i) => (
+              <div
+                key={lib.name}
+                className={`flex items-center justify-between px-3 py-2.5 text-sm ${
+                  i < LICENSES.length - 1
+                    ? "border-b border-[#c4cbd4] dark:border-[#2b3b52]"
+                    : ""
+                }`}
+              >
+                <span className="font-medium">{lib.name}</span>
+                <span className="text-xs text-muted-foreground shrink-0 ml-2">
+                  {lib.license}
+                </span>
+              </div>
+            ))}
+          </Item>
+        </section>
+      </main>
+    </PageContainer>
+  );
+}
+
+export default LicensesPage;

--- a/src/entrypoints/sidepanel/pages/settings/about/licenses.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/about/licenses.tsx
@@ -34,15 +34,15 @@ function LicensesPage() {
   return (
     <PageContainer>
       <PageHeader title="Licenses" goBackButton />
-      <main className="flex flex-col gap-6 w-full pt-4.5 px-1.25 mb-1">
+      <main className="flex flex-col gap-6 w-full pt-4.5 px-1.25 mb-2">
         <section>
-          <p className="text-sm text-muted-foreground ml-2 mb-3">
+          <p className="text-sm text-muted-foreground ml-2 mb-3 text-pretty">
             Lexicora is built on the shoulders of these open source projects.
           </p>
           <Item
             variant="muted"
             size="xs"
-            className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl flex-col items-stretch p-0 overflow-hidden"
+            className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl flex-col gap-0 items-stretch p-0 overflow-hidden"
           >
             {LICENSES.map((lib, i) => (
               <div

--- a/src/entrypoints/sidepanel/pages/settings/data/data.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/data/data.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+} from "@/components/ui/item";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { SettingsItemSeperator } from "@/components/settings";
+import { DownloadIcon, Trash2Icon } from "lucide-react";
+import { useRxCollection } from "rxdb/plugins/react";
+import { toast } from "sonner";
+
+function DataSettingsPage() {
+  const [clearOpen, setClearOpen] = useState(false);
+
+  const topicsCollection = useRxCollection("topics");
+  const entriesCollection = useRxCollection("entries");
+  const blocksCollection = useRxCollection("blocks");
+
+  const handleExport = () => {
+    if (!topicsCollection || !entriesCollection || !blocksCollection) return;
+
+    const p = async () => {
+      const [topics, entries, blocks] = await Promise.all([
+        topicsCollection.find().exec(),
+        entriesCollection.find().exec(),
+        blocksCollection.find().exec(),
+      ]);
+
+      const data = {
+        exportedAt: new Date().toISOString(),
+        version: 1,
+        topics: topics.map((d) => d.toJSON()),
+        entries: entries.map((d) => d.toJSON()),
+        blocks: blocks.map((d) => d.toJSON()),
+      };
+
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `lexicora-export-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    };
+
+    toast.promise(p(), {
+      loading: "Exporting data...",
+      success: "Data exported successfully",
+      error: "Failed to export data",
+    });
+  };
+
+  const handleClear = () => {
+    if (!topicsCollection || !entriesCollection || !blocksCollection) return;
+
+    const p = async () => {
+      const [topicDocs, entryDocs, blockDocs] = await Promise.all([
+        topicsCollection.find().exec(),
+        entriesCollection.find().exec(),
+        blocksCollection.find().exec(),
+      ]);
+
+      await Promise.all([
+        topicsCollection.bulkRemove(topicDocs),
+        entriesCollection.bulkRemove(entryDocs),
+        blocksCollection.bulkRemove(blockDocs),
+      ]);
+    };
+
+    toast.promise(p(), {
+      loading: "Clearing all data...",
+      success: "All data cleared",
+      error: "Failed to clear data",
+    });
+  };
+
+  return (
+    <PageContainer>
+      <PageHeader title="Data Management" goBackButton />
+      <main className="flex flex-col gap-6.5 w-full pt-4.5 px-1.25 mb-1">
+        <section>
+          <Item
+            variant="muted"
+            size="sm"
+            className="group transition-colors duration-150 bg-slate-200/75 hover:bg-slate-300/75! dark:bg-muted/50 dark:hover:bg-muted! rounded-2xl rounded-b-none hover:cursor-pointer"
+            onClick={handleExport}
+          >
+            <ItemMedia variant="icon">
+              <DownloadIcon className="size-5 text-emerald-500" />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Export All Data</ItemTitle>
+              <ItemDescription>
+                Download all your topics, entries, and notes as a JSON file
+              </ItemDescription>
+            </ItemContent>
+          </Item>
+          <SettingsItemSeperator />
+          <Item
+            variant="muted"
+            size="sm"
+            className="group transition-colors duration-150 bg-slate-200/75 hover:bg-slate-300/75! dark:bg-muted/50 dark:hover:bg-muted! rounded-2xl rounded-t-none hover:cursor-pointer"
+            onClick={() => setClearOpen(true)}
+          >
+            <ItemMedia variant="icon">
+              <Trash2Icon className="size-5 text-red-500" />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle className="text-red-600 dark:text-red-400">
+                Clear All Data
+              </ItemTitle>
+              <ItemDescription>
+                Permanently delete all topics, entries, and notes
+              </ItemDescription>
+            </ItemContent>
+          </Item>
+        </section>
+      </main>
+
+      <AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear all data?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete all your topics, entries, and notes.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleClear}>
+              Clear All Data
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </PageContainer>
+  );
+}
+
+export default DataSettingsPage;

--- a/src/entrypoints/sidepanel/pages/settings/data/data.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/data/data.tsx
@@ -54,7 +54,12 @@ function DataSettingsPage() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `lexicora-export-${new Date().toISOString().slice(0, 10)}.json`;
+      const timestamp = new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replace("T", "_")
+        .replace(/:/g, "-");
+      a.download = `lexicora-export-${timestamp}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/src/entrypoints/sidepanel/pages/settings/data/data.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/data/data.tsx
@@ -114,25 +114,32 @@ function DataSettingsPage() {
   return (
     <PageContainer>
       <PageHeader title="Data Management" goBackButton />
-      <main className="flex flex-col gap-6.5 w-full pt-4.5 px-1.25 mb-1">
-        <section>
-          <Item
-            variant="muted"
-            size="sm"
-            className="group transition-colors duration-150 bg-slate-200/75 hover:bg-slate-300/75! dark:bg-muted/50 dark:hover:bg-muted! rounded-2xl rounded-b-none hover:cursor-pointer"
-            onClick={handleExport}
-          >
-            <ItemMedia variant="icon">
-              <DownloadIcon className="size-5 text-emerald-500" />
-            </ItemMedia>
-            <ItemContent>
-              <ItemTitle>Export All Data</ItemTitle>
-              <ItemDescription>
-                Download all your topics, entries, and notes as a JSON file
-              </ItemDescription>
-            </ItemContent>
-          </Item>
-          <SettingsItemSeperator />
+      <main className="flex flex-col gap-6.5 w-full pt-4.5 px-1.25 mb-2">
+        <section className="flex flex-col gap-8">
+          <article>
+            <Item
+              variant="muted"
+              size="sm"
+              className="group transition-colors duration-150 bg-slate-200/75 hover:bg-slate-300/75! dark:bg-muted/50 dark:hover:bg-muted! rounded-2xl hover:cursor-pointer /*bg-clip-padding*/"
+              asChild
+            >
+              <button onClick={handleExport}>
+                <ItemMedia variant="icon">
+                  <DownloadIcon className="size-5 text-emerald-500" />
+                </ItemMedia>
+                <ItemContent>
+                  <ItemTitle>Export All Data</ItemTitle>
+                  {/*<ItemDescription>
+                Download all your topics, entries, and notes as a JSON file.
+              </ItemDescription>*/}
+                </ItemContent>
+              </button>
+            </Item>
+            <p className="text-pretty text-xs text-muted-foreground mx-2.5 mt-1">
+              Download all your topics, entries, and notes as a JSON file.
+            </p>
+          </article>
+          {/*<SettingsItemSeperator />*/}
           {/* Clear All Data — temporarily disabled: RxDB soft-delete does not
               physically remove documents from IndexedDB, causing data to reappear
               after reopening the extension. See the TODO comment above. */}
@@ -156,24 +163,30 @@ function DataSettingsPage() {
             </ItemContent>
           </Item>
           */}
-          <Item
-            variant="muted"
-            size="sm"
-            className="opacity-65 grayscale-30 bg-slate-200/75 dark:bg-muted/50 rounded-2xl rounded-t-none"
-          >
-            <ItemMedia variant="icon">
-              <Trash2Icon className="size-5 text-red-500" />
-            </ItemMedia>
-            <ItemContent>
-              <ItemTitle className="text-red-600 dark:text-red-400">
-                Clear All Data
-              </ItemTitle>
-              <ItemDescription className="line-clamp-none">
-                To clear all data, remove and reinstall the extension. This
-                feature will be re-enabled in a future update.
-              </ItemDescription>
-            </ItemContent>
-          </Item>
+          <article className="opacity-65 grayscale-30">
+            <Item
+              variant="muted"
+              size="sm"
+              className="bg-slate-200/75 dark:bg-muted/50 rounded-2xl"
+            >
+              <ItemMedia variant="icon">
+                <Trash2Icon className="size-5 text-red-500" />
+              </ItemMedia>
+              <ItemContent>
+                <ItemTitle className="text-red-600 dark:text-red-400">
+                  Clear All Data
+                </ItemTitle>
+                {/*<ItemDescription className="line-clamp-none">
+                  To clear all data, remove and reinstall the extension. This
+                  feature will be re-enabled in a future update.
+                </ItemDescription>*/}
+              </ItemContent>
+            </Item>
+            <p className="text-pretty text-xs text-muted-foreground mx-2.5 mt-1">
+              To clear all data, remove and reinstall the extension. This
+              feature will be re-enabled in a future update.
+            </p>
+          </article>
         </section>
       </main>
 

--- a/src/entrypoints/sidepanel/pages/settings/data/data.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/data/data.tsx
@@ -24,7 +24,21 @@ import { useRxCollection } from "rxdb/plugins/react";
 import { toast } from "sonner";
 
 function DataSettingsPage() {
-  const [clearOpen, setClearOpen] = useState(false);
+  // TODO: Re-enable clear all data once the soft-delete issue is resolved.
+  // RxDB's bulkRemove() only soft-deletes documents (sets "_deleted": true); it does
+  // not physically remove them from IndexedDB. As a result, on closing and reopening
+  // the extension the soft-deleted documents reappear in the UI despite the flag still
+  // being set. This should be investigated when implementing the cleanup logic that
+  // physically purges soft-deleted documents from IndexedDB.
+  //
+  // Before re-enabling, also verify transaction finality per rxdb.info:
+  //   // .commit() is not available on all browsers, so first check if it exists.
+  //   if (transaction.commit) {
+  //     transaction.commit()
+  //   }
+  //
+  // See: https://rxdb.info/cleanup.html
+  // const [clearOpen, setClearOpen] = useState(false);
 
   const topicsCollection = useRxCollection("topics");
   const entriesCollection = useRxCollection("entries");
@@ -73,29 +87,29 @@ function DataSettingsPage() {
     });
   };
 
-  const handleClear = () => {
-    if (!topicsCollection || !entriesCollection || !blocksCollection) return;
-
-    const p = async () => {
-      const [topicDocs, entryDocs, blockDocs] = await Promise.all([
-        topicsCollection.find().exec(),
-        entriesCollection.find().exec(),
-        blocksCollection.find().exec(),
-      ]);
-
-      await Promise.all([
-        topicsCollection.bulkRemove(topicDocs),
-        entriesCollection.bulkRemove(entryDocs),
-        blocksCollection.bulkRemove(blockDocs),
-      ]);
-    };
-
-    toast.promise(p(), {
-      loading: "Clearing all data...",
-      success: "All data cleared",
-      error: "Failed to clear data",
-    });
-  };
+  // const handleClear = () => {
+  //   if (!topicsCollection || !entriesCollection || !blocksCollection) return;
+  //
+  //   const p = async () => {
+  //     const [topicDocs, entryDocs, blockDocs] = await Promise.all([
+  //       topicsCollection.find().exec(),
+  //       entriesCollection.find().exec(),
+  //       blocksCollection.find().exec(),
+  //     ]);
+  //
+  //     await Promise.all([
+  //       topicsCollection.bulkRemove(topicDocs),
+  //       entriesCollection.bulkRemove(entryDocs),
+  //       blocksCollection.bulkRemove(blockDocs),
+  //     ]);
+  //   };
+  //
+  //   toast.promise(p(), {
+  //     loading: "Clearing all data...",
+  //     success: "All data cleared",
+  //     error: "Failed to clear data",
+  //   });
+  // };
 
   return (
     <PageContainer>
@@ -119,6 +133,10 @@ function DataSettingsPage() {
             </ItemContent>
           </Item>
           <SettingsItemSeperator />
+          {/* Clear All Data — temporarily disabled: RxDB soft-delete does not
+              physically remove documents from IndexedDB, causing data to reappear
+              after reopening the extension. See the TODO comment above. */}
+          {/*
           <Item
             variant="muted"
             size="sm"
@@ -137,9 +155,30 @@ function DataSettingsPage() {
               </ItemDescription>
             </ItemContent>
           </Item>
+          */}
+          <Item
+            variant="muted"
+            size="sm"
+            className="opacity-65 grayscale-30 bg-slate-200/75 dark:bg-muted/50 rounded-2xl rounded-t-none"
+          >
+            <ItemMedia variant="icon">
+              <Trash2Icon className="size-5 text-red-500" />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle className="text-red-600 dark:text-red-400">
+                Clear All Data
+              </ItemTitle>
+              <ItemDescription className="line-clamp-none">
+                To clear all data, remove and reinstall the extension. This
+                feature will be re-enabled in a future update.
+              </ItemDescription>
+            </ItemContent>
+          </Item>
         </section>
       </main>
 
+      {/* AlertDialog for clear confirmation — disabled until soft-delete issue is resolved */}
+      {/*
       <AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
@@ -157,6 +196,7 @@ function DataSettingsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      */}
     </PageContainer>
   );
 }

--- a/src/entrypoints/sidepanel/pages/settings/help/faq.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/help/faq.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
+import { ChevronDownIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const FAQ_ITEMS = [
+  {
+    question: "What is Lexicora?",
+    answer:
+      "Lexicora is a browser extension that lets you capture and organize web content. Save pages, highlight text, and write notes — all stored locally in your browser.",
+  },
+  {
+    question: "How do I capture a webpage?",
+    answer:
+      "Navigate to any webpage and click the Lexicora icon in your browser toolbar to open the side panel. From there you can create a new entry and the page URL and metadata will be pre-filled. You can also use the capture suggestion prompt that appears after spending time on a page.",
+  },
+  {
+    question: "How do I organize my captures?",
+    answer:
+      "Use topics to group related entries together. Think of topics like folders or projects. Create a topic from the Library tab, then assign entries to it when capturing or editing.",
+  },
+  {
+    question: "Where is my data stored?",
+    answer:
+      "All data is stored locally in your browser using IndexedDB. Nothing is sent to any server. Your data stays on your device and is private to you.",
+  },
+  {
+    question: "Can I use Lexicora offline?",
+    answer:
+      "Yes. Lexicora is fully offline-first. All features work without an internet connection. Your captures, notes, and topics are stored locally and always available.",
+  },
+  {
+    question: "How do I search my captures?",
+    answer:
+      "Use the search bar at the top of the Library tab to search across all your entries and topics. Search works on titles, tags, descriptions, and site names.",
+  },
+  {
+    question: "How do I export my data?",
+    answer:
+      "Go to Settings → Data Management → Export All Data. This downloads a JSON file containing all your topics, entries, and notes that you can use for backup or migration.",
+  },
+] as const;
+
+function FaqItem({
+  question,
+  answer,
+}: {
+  question: string;
+  answer: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger
+        className={cn(
+          "w-full text-left flex items-center justify-between gap-2.5 px-3 py-2.5",
+          "bg-slate-200/75 hover:bg-slate-300/75 dark:bg-muted/50 dark:hover:bg-muted",
+          "transition-colors duration-150",
+          open ? "rounded-t-2xl" : "rounded-2xl",
+        )}
+      >
+        <span className="text-sm font-medium">{question}</span>
+        <ChevronDownIcon
+          className={cn(
+            "size-4 text-muted-foreground shrink-0 transition-transform duration-200",
+            open && "rotate-180",
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="px-3 pb-3 pt-2.5 text-sm text-muted-foreground bg-slate-100/75 dark:bg-muted/30 rounded-b-2xl leading-relaxed">
+          {answer}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function FaqPage() {
+  return (
+    <PageContainer>
+      <PageHeader title="FAQ" goBackButton />
+      <main className="flex flex-col gap-2 w-full pt-4.5 px-1.25 mb-1">
+        {FAQ_ITEMS.map((item) => (
+          <FaqItem key={item.question} question={item.question} answer={item.answer} />
+        ))}
+      </main>
+    </PageContainer>
+  );
+}
+
+export default FaqPage;

--- a/src/entrypoints/sidepanel/pages/settings/help/faq.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/help/faq.tsx
@@ -47,13 +47,7 @@ const FAQ_ITEMS = [
   },
 ] as const;
 
-function FaqItem({
-  question,
-  answer,
-}: {
-  question: string;
-  answer: string;
-}) {
+function FaqItem({ question, answer }: { question: string; answer: string }) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -75,7 +69,7 @@ function FaqItem({
         />
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="px-3 pb-3 pt-2.5 text-sm text-muted-foreground bg-slate-100/75 dark:bg-muted/30 rounded-b-2xl leading-relaxed">
+        <div className="px-3 pb-3 pt-2.5 text-sm text-muted-foreground bg-slate-100/75 dark:bg-muted/30 rounded-b-2xl leading-relaxed text-pretty">
           {answer}
         </div>
       </CollapsibleContent>
@@ -87,9 +81,13 @@ function FaqPage() {
   return (
     <PageContainer>
       <PageHeader title="FAQ" goBackButton />
-      <main className="flex flex-col gap-2 w-full pt-4.5 px-1.25 mb-1">
+      <main className="flex flex-col gap-3.5 w-full pt-4.5 px-1.25 mb-2">
         {FAQ_ITEMS.map((item) => (
-          <FaqItem key={item.question} question={item.question} answer={item.answer} />
+          <FaqItem
+            key={item.question}
+            question={item.question}
+            answer={item.answer}
+          />
         ))}
       </main>
     </PageContainer>

--- a/src/entrypoints/sidepanel/pages/settings/help/tips-and-tricks.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/help/tips-and-tricks.tsx
@@ -74,7 +74,7 @@ function TipsAndTricksPage() {
   return (
     <PageContainer>
       <PageHeader title="Tips & Tricks" goBackButton />
-      <main className="flex flex-col gap-0 w-full pt-4.5 px-1.25 mb-1">
+      <main className="flex flex-col gap-0 w-full pt-4.5 px-1.25 mb-2">
         <section>
           {TIPS.map((tip, i) => {
             const isFirst = i === 0;
@@ -98,7 +98,7 @@ function TipsAndTricksPage() {
                   </ItemMedia>
                   <ItemContent>
                     <ItemTitle>{tip.title}</ItemTitle>
-                    <ItemDescription className="line-clamp-none">
+                    <ItemDescription className="line-clamp-none text-pretty">
                       {tip.description}
                     </ItemDescription>
                   </ItemContent>

--- a/src/entrypoints/sidepanel/pages/settings/help/tips-and-tricks.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/help/tips-and-tricks.tsx
@@ -1,0 +1,115 @@
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+} from "@/components/ui/item";
+import { SettingsItemSeperator } from "@/components/settings";
+import {
+  ArchiveIcon,
+  BookmarkIcon,
+  CameraIcon,
+  FolderOpenIcon,
+  PinIcon,
+  SearchIcon,
+  TagIcon,
+} from "lucide-react";
+
+const TIPS = [
+  {
+    icon: CameraIcon,
+    iconColor: "text-red-500",
+    title: "Tune capture suggestions",
+    description:
+      "Adjust the capture prompt delay in Settings → Capture Suggestions so it appears after the right amount of time for your browsing habits.",
+  },
+  {
+    icon: FolderOpenIcon,
+    iconColor: "text-blue-500",
+    title: "Organize with topics",
+    description:
+      "Create topics for projects, research areas, or themes. Assign entries to topics when capturing so related content stays together.",
+  },
+  {
+    icon: TagIcon,
+    iconColor: "text-violet-500",
+    title: "Tag across topics",
+    description:
+      "Tags let you cross-reference entries across different topics. Use consistent tags to find related content at a glance.",
+  },
+  {
+    icon: PinIcon,
+    iconColor: "text-amber-500",
+    title: "Pin what matters",
+    description:
+      "Pin important entries or topics to keep them at the top of your lists so you can get back to them quickly.",
+  },
+  {
+    icon: ArchiveIcon,
+    iconColor: "text-slate-500",
+    title: "Archive to declutter",
+    description:
+      "Archive entries you want to keep but don't need front and center. Archived entries are hidden from the main list but remain searchable.",
+  },
+  {
+    icon: SearchIcon,
+    iconColor: "text-cyan-500",
+    title: "Search is powerful",
+    description:
+      "The search bar scans titles, tags, descriptions, and site names. Try searching by domain name to find all captures from a site.",
+  },
+  {
+    icon: BookmarkIcon,
+    iconColor: "text-emerald-500",
+    title: "Add your own notes",
+    description:
+      "Every entry has a rich text editor for your own notes, highlights, and thoughts. Use it to annotate what you captured and why.",
+  },
+] as const;
+
+function TipsAndTricksPage() {
+  return (
+    <PageContainer>
+      <PageHeader title="Tips & Tricks" goBackButton />
+      <main className="flex flex-col gap-0 w-full pt-4.5 px-1.25 mb-1">
+        <section>
+          {TIPS.map((tip, i) => {
+            const isFirst = i === 0;
+            const isLast = i === TIPS.length - 1;
+            const roundingClass = isFirst
+              ? "rounded-2xl rounded-b-none"
+              : isLast
+                ? "rounded-2xl rounded-t-none"
+                : "rounded-none";
+
+            return (
+              <div key={tip.title}>
+                {i > 0 && <SettingsItemSeperator />}
+                <Item
+                  variant="muted"
+                  size="sm"
+                  className={`bg-slate-200/75 dark:bg-muted/50 ${roundingClass}`}
+                >
+                  <ItemMedia variant="icon">
+                    <tip.icon className={`size-5 ${tip.iconColor}`} />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>{tip.title}</ItemTitle>
+                    <ItemDescription className="line-clamp-none">
+                      {tip.description}
+                    </ItemDescription>
+                  </ItemContent>
+                </Item>
+              </div>
+            );
+          })}
+        </section>
+      </main>
+    </PageContainer>
+  );
+}
+
+export default TipsAndTricksPage;

--- a/src/entrypoints/sidepanel/pages/settings/personalization/theme.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/personalization/theme.tsx
@@ -92,7 +92,6 @@ function ThemePersonalizationSettingsPage() {
           </p>
         </section>
       </main>
-      <footer>{/* Footer content if needed */}</footer>
     </PageContainer>
   );
 }

--- a/src/entrypoints/sidepanel/pages/settings/settings.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/settings.tsx
@@ -39,6 +39,8 @@ import { SettingsItem } from "@/components/settings";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 
+// TODO: Maybe convert this whole page full of options to a data list, that gets iterated over.
+
 function SettingsPage() {
   return (
     <PageContainer>

--- a/src/entrypoints/sidepanel/pages/settings/settings.tsx
+++ b/src/entrypoints/sidepanel/pages/settings/settings.tsx
@@ -15,6 +15,7 @@ import { SparklesIcon } from "@heroicons/react/24/solid";
 import {
   CameraIcon,
   ChevronRightIcon,
+  DatabaseIcon,
   EllipsisIcon,
   FileTextIcon,
   HeartPlusIcon,
@@ -141,6 +142,19 @@ function SettingsPage() {
             <div className="flex-1 w-full h-0 max-w-[calc(100%-57px)] border-t border-t-slate-300/75 dark:border-t-muted"></div>
             <div className="shrink-0 w-3.75 h-0 border-t border-t-slate-200/75 dark:border-t-muted/50"></div>
           </div>*/}
+        </section>
+        <section id="data-settings">
+          <Label htmlFor="" className="text-sm ml-2 mb-0.5">
+            <DatabaseIcon className="size-3.5 text-emerald-400" /> Data
+          </Label>
+          <SettingsItem
+            to="/settings/data"
+            size="sm"
+            MediaIcon={DatabaseIcon}
+            mediaIconColor="text-emerald-500"
+            itemTitle="Data Management"
+            roundingClass=""
+          />
         </section>
         <section id="general-settings">
           <Label htmlFor="" className="text-sm ml-2 mb-0.5">


### PR DESCRIPTION
## Summary

- Adds a **Data Management** section to the settings index page, with an export-all-data action and a (temporarily disabled) clear-all-data action
- Implements **About** and **Licenses** pages (version from manifest, open-source attributions for 25 libraries)
- Implements **FAQ** and **Tips & Tricks** pages under Help with static content
- Wires up 5 new routes in `App.tsx`

## Changes

### New pages
| Route | Page |
|---|---|
| `/settings/data` | Export all data (JSON download) · Clear all data (disabled — see below) |
| `/settings/about` | App name, version, description, link to Licenses |
| `/settings/about/licenses` | 25 open-source library attributions |
| `/settings/help/faq` | 7 collapsible Q&A items |
| `/settings/help/tips-and-tricks` | 7 informational tips |

### Settings index
Added a **Data** section between Personalization and General.

### Clear All Data — temporarily disabled
`RxCollection.bulkRemove()` only soft-deletes documents (`_deleted: true`); data reappears after reopening the extension. The implementation is left intact but commented out, replaced with a note to remove and reinstall. Tracked in #153.

## Test plan
- [x] Navigate to Settings → Data Management → Export All Data — confirm JSON file downloads with correct filename (`lexicora-export-YYYY-MM-DD_HH-MM-SS.json`) and valid content
- [x] Clear All Data row is visible but grayed out with reinstall note
- [x] Settings → About — version number matches `manifest.json`; Open Source Licenses link navigates correctly
- [x] Settings → About → Licenses — all 25 libraries listed
- [x] Settings → Help → FAQ — each item expands/collapses independently
- [x] Settings → Help → Tips & Tricks — all 7 tips render
- [x] All existing settings nav items (Account, AI, General, etc.) still appear and link as before
- [x] Back navigation works on all new pages

Closes #143, closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)